### PR TITLE
Persist patches for cage in nixpkgs.overlays

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -82,7 +82,7 @@
       (self: super: {
         # patched version of cage that fixes window centering
         cage = super.cage.overrideAttrs (old: {
-          patches = [
+          patches = (old.patches or []) ++ [
             (super.fetchpatch {
               url = "https://patch-diff.githubusercontent.com/raw/cage-kiosk/cage/pull/365.patch";
               hash = "sha256-Grap5a3+8JkxMGS2dFLcKrElDvjq9QKaLQqhL722keo=";


### PR DESCRIPTION
This will make `pkgs.cage` patches from outside the flake apply instead of them being overwritten.