### PR TITLE
Delete nix.conf symlink which points to nix-store before filling /etc/nix/nix.conf

### DIFF
--- a/docker/Dockerfile.nix
+++ b/docker/Dockerfile.nix
@@ -3,6 +3,8 @@ FROM nixos/nix AS base
 # arm64-specific stage
 FROM base AS build-arm64
 
+RUN rm /etc/nix/nix.conf
+
 RUN <<EOR
 tee /etc/nix/nix.conf << EOF
 build-users-group = nixbld
@@ -22,6 +24,8 @@ RUN nix-channel --update
 
 # amd64-specific stage
 FROM base AS build-amd64
+
+RUN rm /etc/nix/nix.conf
 
 RUN <<EOR
 tee /etc/nix/nix.conf << EOF


### PR DESCRIPTION
The file `/etc/nix/nix.conf` is a symlink to the nix-store on the base image, so appending these config options to it doesn't persist after the build.

This deletes the symlink so it can be replaced by the actual file.